### PR TITLE
Removed id key from message_dict while converting messages to dict

### DIFF
--- a/libs/databricks/langchain_databricks/chat_models.py
+++ b/libs/databricks/langchain_databricks/chat_models.py
@@ -422,9 +422,6 @@ def _convert_message_to_dict(message: BaseMessage) -> dict:
     if (name := message.name or message.additional_kwargs.get("name")) is not None:
         message_dict["name"] = name
 
-    if id := message.id:
-        message_dict["id"] = id
-
     if isinstance(message, ChatMessage):
         return {"role": message.role, **message_dict}
     elif isinstance(message, HumanMessage):


### PR DESCRIPTION
The message_dict was updated to exclude the message id key, which was found to be unnecessary. This change addressed an issue that arose when passing id from AIMessage resulting in `HTTPError: 400 Client Error: Bad request: json: unknown field "id" for url:
Response text: {"error_code": "BAD_REQUEST", "message": "Bad request: json: unknown field \"id\"\n"}. `

The error described above was encountered while passing the chat history as a dictionary to the LLM, which is utilized for context-aware conversation.