### PR TITLE
Stop propagating 'id' field from Message object to request payload

### DIFF
--- a/libs/databricks/langchain_databricks/chat_models.py
+++ b/libs/databricks/langchain_databricks/chat_models.py
@@ -422,9 +422,6 @@ def _convert_message_to_dict(message: BaseMessage) -> dict:
     if (name := message.name or message.additional_kwargs.get("name")) is not None:
         message_dict["name"] = name
 
-    if id := message.id:
-        message_dict["id"] = id
-
     if isinstance(message, ChatMessage):
         return {"role": message.role, **message_dict}
     elif isinstance(message, HumanMessage):

--- a/libs/databricks/tests/unit_tests/test_chat_models.py
+++ b/libs/databricks/tests/unit_tests/test_chat_models.py
@@ -276,6 +276,7 @@ def test_convert_message_with_tool_calls() -> None:
 
     # convert back
     dict_result = _convert_message_to_dict(result)
+    message_with_tools.pop("id")  # id is not propagated
     assert dict_result == message_with_tools
 
 
@@ -329,6 +330,7 @@ def test_convert_tool_message_chunk() -> None:
 
     # convert back
     dict_result = _convert_message_to_dict(result)
+    delta.pop("id")  # id is not propagated
     assert dict_result == delta
 
 

--- a/libs/databricks/tests/unit_tests/test_chat_models.py
+++ b/libs/databricks/tests/unit_tests/test_chat_models.py
@@ -231,6 +231,15 @@ def test_convert_message(role: str, expected_output: BaseMessage) -> None:
     assert dict_result == message
 
 
+def test_convert_message_not_propagate_id() -> None:
+    # The AIMessage returned by the model endpoint can contain "id" field,
+    # but it is not always supported for requests. Therefore, we should not
+    # propagate it to the request payload.
+    message = AIMessage(content="foo", id="some-id")
+    result = _convert_message_to_dict(message)
+    assert result == {"role": "assistant", "content": "foo"}
+
+
 def test_convert_message_with_tool_calls() -> None:
     ID = "call_fb5f5e1a-bac0-4422-95e9-d06e6022ad12"
     tool_calls = [

--- a/libs/databricks/tests/unit_tests/test_chat_models.py
+++ b/libs/databricks/tests/unit_tests/test_chat_models.py
@@ -237,7 +237,7 @@ def test_convert_message_not_propagate_id() -> None:
     # propagate it to the request payload.
     message = AIMessage(content="foo", id="some-id")
     result = _convert_message_to_dict(message)
-    assert result == {"role": "assistant", "content": "foo"}
+    assert "id" not in result
 
 
 def test_convert_message_with_tool_calls() -> None:


### PR DESCRIPTION
Resolving https://github.com/langchain-ai/langchain-databricks/issues/6

The new `ChatDatabricks` implementation propagates the `id` fields from the input `Message` objects to the underlying model endpoint. It causes an error because not all endpoints support `id` field in the input payload e.g. our FMAPIs.

Indeed, the input messages often do not have `id` fields if it is specified by users. However, when we pass the chat history to the `ChatDatabricks` class, it contains `AIMessage` objects from the previous response, which often contain `id` field.

Indeed, this is regressoin fromthe old community [ChatDatabricks](https://github.com/langchain-ai/langchain/blob/17659ca2cdc418436edf2f8c7f50e800dbbf31ca/libs/community/langchain_community/chat_models/mlflow.py#L336), which does not propagate `id` field. Therefore, this PR simply revert the new class to original behavior.


**Testing**
* Unit test
* Validated with the sample code user provided in the issue ^