### PR TITLE
Disable integraion tests during release workflow

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -157,9 +157,10 @@ jobs:
         run: make tests
         working-directory: ${{ inputs.working-directory }}
 
-      - name: Run integration tests
-        run: make integration_tests
-        working-directory: ${{ inputs.working-directory }}
+      # Integration test is executed nightly in the separate private repository.
+      # - name: Run integration tests
+      #   run: make integration_tests
+      #   working-directory: ${{ inputs.working-directory }}
 
       - name: Get minimum versions
         working-directory: ${{ inputs.working-directory }}


### PR DESCRIPTION
We are running the nightly integration test in a separate private package, so it shouldn't be included in the release workflow.

