### PR TITLE
Client Arguments for DatabricksVectorSearch

### DIFF
--- a/libs/databricks/langchain_databricks/vectorstores.py
+++ b/libs/databricks/langchain_databricks/vectorstores.py
@@ -86,6 +86,10 @@ class DatabricksVectorSearch(VectorStore):
                     Make sure the text column specified is in the index.
         columns: The list of column names to get when doing the search.
                 Defaults to ``[primary_key, text_column]``.
+        client_args: Additional arguments to pass to the VectorSearchClient.
+                    Allows you to pass in values like `service_principal_client_id`
+                    and `service_principal_client_secret` for to allow for
+                    service principal authentication instead of personal access token authentication.
 
     Instantiate:
 
@@ -214,6 +218,7 @@ class DatabricksVectorSearch(VectorStore):
         embedding: Optional[Embeddings] = None,
         text_column: Optional[str] = None,
         columns: Optional[List[str]] = None,
+        client_args: Optional[Dict[str, Any]] = None,
     ):
         if not isinstance(index_name, str):
             raise ValueError(
@@ -232,7 +237,7 @@ class DatabricksVectorSearch(VectorStore):
             ) from e
 
         try:
-            self.index = VectorSearchClient().get_index(
+            self.index = VectorSearchClient(**client_args).get_index(
                 endpoint_name=endpoint, index_name=index_name
             )
         except Exception as e:


### PR DESCRIPTION
This PR allows new instances of `DatabricksVectorSearch` to pass custom arguments to the underlying `VectorSearchClient` (imported from `databricks.vector_search.client`).

This allows users to be able to use Service Principal based authentication by passing in `service_principal_client_id` or `service_principal_client_secret` within the new `client_args` parameter.