### PR TITLE
Fix test_chat_databricks_invoke with llama 3.3

### DIFF
--- a/libs/databricks/tests/integration_tests/test_chat_models.py
+++ b/libs/databricks/tests/integration_tests/test_chat_models.py
@@ -45,9 +45,9 @@ def test_chat_databricks_invoke():
     response = chat.invoke("How to learn Java? Start the response by 'To learn Java,'")
     assert isinstance(response, AIMessage)
     assert response.content == "To learn "
-    assert response.response_metadata["prompt_tokens"] == 24
+    assert response.response_metadata["prompt_tokens"] == 25
     assert response.response_metadata["completion_tokens"] == 3
-    assert response.response_metadata["total_tokens"] == 27
+    assert response.response_metadata["total_tokens"] == 28
 
     response = chat.invoke(
         "How to learn Python? Start the response by 'To learn Python,'"

--- a/libs/databricks/tests/integration_tests/test_chat_models.py
+++ b/libs/databricks/tests/integration_tests/test_chat_models.py
@@ -45,9 +45,10 @@ def test_chat_databricks_invoke():
     response = chat.invoke("How to learn Java? Start the response by 'To learn Java,'")
     assert isinstance(response, AIMessage)
     assert response.content == "To learn "
-    assert response.response_metadata["prompt_tokens"] == 25
-    assert response.response_metadata["completion_tokens"] == 3
-    assert response.response_metadata["total_tokens"] == 28
+    assert 20 <= response.response_metadata["prompt_tokens"] <= 30
+    assert 1 <= response.response_metadata["completion_tokens"] <= 10
+    expected_total = response.response_metadata["prompt_tokens"] + response.response_metadata["completion_tokens"]
+    assert response.response_metadata["total_tokens"] == expected_total
 
     response = chat.invoke(
         "How to learn Python? Start the response by 'To learn Python,'"

--- a/libs/databricks/tests/integration_tests/test_chat_models.py
+++ b/libs/databricks/tests/integration_tests/test_chat_models.py
@@ -47,7 +47,10 @@ def test_chat_databricks_invoke():
     assert response.content == "To learn "
     assert 20 <= response.response_metadata["prompt_tokens"] <= 30
     assert 1 <= response.response_metadata["completion_tokens"] <= 10
-    expected_total = response.response_metadata["prompt_tokens"] + response.response_metadata["completion_tokens"]
+    expected_total = (
+        response.response_metadata["prompt_tokens"]
+        + response.response_metadata["completion_tokens"]
+    )
     assert response.response_metadata["total_tokens"] == expected_total
 
     response = chat.invoke(


### PR DESCRIPTION
Update `test_chat_databricks_invoke` with appropriate values from llama 3.3 on databricks. 

Relax test validation to prevent failures.