### PR TITLE
Introduce deprecations to langchain-databricks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,193 +1,48 @@
-# 🦜️🔗 LangChain Databricks
+# 🦜️🔗 LangChain Databricks (Deprecated)
 
-This repository provides LangChain components to connect your LangChain application with various Databricks services.
+This repository previously provided LangChain components to connect your LangChain application with various Databricks services.
 
-## Upcoming Package Consolidation Notice
-This package (`langchain-databricks`) will soon be consolidated into a new package: `databricks-langchain`. The new package will serve as the primary hub for all Databricks Langchain integrations.
+## Deprecation Notice
 
-### What’s Changing?
-In the coming months, `databricks-langchain` will include all features currently in `langchain-databricks`, as well as additional integrations to provide a unified experience for Databricks users.
+The `langchain-databricks` package is now deprecated in favor of the consolidated package [`databricks-langchain`](https://pypi.org/project/databricks-langchain/). Please update your dependencies to use `databricks-langchain` going forward.
 
-### What You Need to Know
-For now, continue to use `langchain-databricks` as usual. When `databricks-langchain` is ready, we’ll provide clear migration instructions to make the transition seamless. During the transition period, `langchain-databricks` will remain operational, and updates will be shared here with timelines and guidance.
+### Migration Guide
 
-Thank you for your support as we work toward an improved, streamlined experience!
+#### What’s Changing?
 
-## Features
+- All features previously provided by `langchain-databricks` are now available in `databricks-langchain`.
+- Future updates and new features will be released exclusively in `databricks-langchain`.
 
-- **🤖 LLMs**: The `ChatDatabricks` component allows you to access chat endpoints hosted on [Databricks Model Serving](https://www.databricks.com/product/model-serving), including state-of-the-art models such as Llama3, Mixtral, and DBRX, as well as your own fine-tuned models.
-- **📐 Vector Store**: [Databricks Vector Search](https://www.databricks.com/product/machine-learning/vector-search) is a serverless similarity search engine that allows you to store a vector representation of your data, including metadata, in a vector database. With Vector Search, you can create auto-updating vector search indexes from Delta tables managed by Unity Catalog and query them with a simple API to return the most similar vectors.
-- **🔢 Embeddings**: Provides components for working with embedding models hosted on [Databricks Model Serving](https://www.databricks.com/product/model-serving).
-- **📊 MLflow Integration**: LangChain Databricks components are fully integrated with [MLflow](https://python.langchain.com/docs/integrations/providers/mlflow_tracking/), providing various LLMOps capabilities such as experiment tracking, dependency management, evaluation, and tracing (observability).
+#### How to Migrate
 
-**Note**: This repository will replace all Databricks integrations currently present in the `langchain-community` package. Users are encouraged to migrate to this repository as soon as possible.
+1. **Install the new package:**
 
-## Installation
+    ```bash
+    pip install databricks-langchain
+    ```
 
-You can install the `langchain-databricks` package from PyPI.
+2. **Update Imports:** Replace occurrences of `langchain_databricks` in your code with `databricks_langchain`. Example:
+   ```python
+   from databricks_langchain import ChatDatabricks
 
-```bash
-pip install langchain-databricks
-```
+   chat_model = ChatDatabricks(endpoint="databricks-meta-llama-3-70b-instruct")
+   response = chat_model.invoke("What is MLflow?")
+   print(response)
+   ```
 
-## Usage
+For more details, please refer to the [Langchain documentation](https://python.langchain.com/docs/integrations/providers/databricks/) and the [databricks-langchain package](https://pypi.org/project/databricks-langchain/). 
 
-Here's a simple example of how to use the `langchain-databricks` package.
-
-```python
-from langchain_databricks import ChatDatabricks
-
-chat_model = ChatDatabricks(endpoint="databricks-meta-llama-3-70b-instruct")
-
-response = chat_model.invoke("What is MLflow?")
-print(response)
-```
-
-For more detailed usage examples and documentation, please refer to the [LangChain documentation](https://python.langchain.com/docs/integrations/providers/databricks//).
+---
 
 ## Contributing
 
-We welcome contributions to this project! Please follow the following guidance to setup the project for development and start contributing.
+Contributions are now accepted in the `databricks-langchain` repository. Please refer to its [contribution guide](https://github.com/databricks/databricks-ai-bridge/tree/main/integrations/langchain) for more details.
 
-### Folk and clone the repository
-
-To contribute to this project, please follow the ["fork and pull request"](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project) workflow. Please do not try to push directly to this repo unless you are a maintainer.
-
-
-### Dependency Management: Poetry and other env/dependency managers
-
-This project utilizes [Poetry](https://python-poetry.org/) v1.7.1+ as a dependency manager.
-
-❗Note: *Before installing Poetry*, if you use `Conda`, create and activate a new Conda env (e.g. `conda create -n langchain python=3.9`)
-
-Install Poetry: **[documentation on how to install it](https://python-poetry.org/docs/#installation)**.
-
-❗Note: If you use `Conda` or `Pyenv` as your environment/package manager, after installing Poetry,
-tell Poetry to use the virtualenv python environment (`poetry config virtualenvs.prefer-active-python true`)
-
-### Local Development Dependencies
-
-The project configuration and the makefile for running dev commands are located under the `libs/databricks` directory.
-
-```bash
-cd libs/databricks
-```
-
-Install langchain-databricks development requirements (for running langchain, running examples, linting, formatting, tests, and coverage):
-
-```bash
-poetry install --with lint,typing,test,test_integration,dev
-```
-
-Then verify the installation.
-
-```bash
-make test
-```
-
-If during installation you receive a `WheelFileValidationError` for `debugpy`, please make sure you are running
-Poetry v1.6.1+. This bug was present in older versions of Poetry (e.g. 1.4.1) and has been resolved in newer releases.
-If you are still seeing this bug on v1.6.1+, you may also try disabling "modern installation"
-(`poetry config installer.modern-installation false`) and re-installing requirements.
-See [this `debugpy` issue](https://github.com/microsoft/debugpy/issues/1246) for more details.
-
-### Testing
-
-Unit tests cover modular logic that does not require calls to outside APIs.
-If you add new logic, please add a unit test.
-
-To run unit tests:
-
-```bash
-make test
-```
-
-Integration tests cover the end-to-end service calls as much as possible.
-However, in certain cases this might not be practical, so you can mock the 
-service response for these tests. There are examples of this in the repo, 
-that can help you write your own tests. If you have suggestions to improve
-this, please get in touch with us.
-
-To run the integration tests:
-
-```bash
-make integration_test
-```
-
-### Formatting and Linting
-
-Formatting ensures that the code in this repo has consistent style so that the
-code looks more presentable and readable. It corrects these errors when you run
-the formatting command. Linting finds and highlights the code errors and helps 
-avoid coding practicies that can lead to errors. 
-
-Run both of these locally before submitting a PR. The CI scripts will run these
-when you submit a PR, and you won't be able to merge changes without fixing 
-issues identified by the CI.
-
-#### Code Formatting
-
-Formatting for this project is done via [ruff](https://docs.astral.sh/ruff/rules/).
-
-To run format:
-
-```bash
-make format
-```
-
-Additionally, you can run the formatter only on the files that have been modified in your current branch 
-as compared to the master branch using the `format_diff` command. This is especially useful when you have 
-made changes to a subset of the project and want to ensure your changes are properly formatted without 
-affecting the rest of the codebase.
-
-```bash
-make format_diff
-```
-
-#### Linting
-
-Linting for this project is done via a combination of [ruff](https://docs.astral.sh/ruff/rules/) and [mypy](http://mypy-lang.org/).
-
-To run lint:
-
-```bash
-make lint
-```
-
-In addition, you can run the linter only on the files that have been modified in your current branch as compared to the master branch using the `lint_diff` command. This can be very helpful when you've made changes to only certain parts of the project and want to ensure your changes meet the linting standards without having to check the entire codebase.
-
-```bash
-make lint_diff
-```
-
-We recognize linting can be annoying - if you do not want to do it, please contact a project maintainer, and they can help you with it. We do not want this to be a blocker for good code getting contributed.
-
-#### Spellcheck
-
-Spellchecking for this project is done via [codespell](https://github.com/codespell-project/codespell).
-Note that `codespell` finds common typos, so it could have false-positive (correctly spelled but rarely used) and false-negatives (not finding misspelled) words.
-
-To check spelling for this project:
-
-```bash
-make spell_check
-```
-
-To fix spelling in place:
-
-```bash
-make spell_fix
-```
-
-If codespell is incorrectly flagging a word, you can skip spellcheck for that word by adding it to the codespell config in the `pyproject.toml` file.
-
-```python
-[tool.codespell]
-...
-# Add here:
-ignore-words-list = 'momento,collison,ned,foor,reworkd,parth,whats,aapply,mysogyny,unsecure'
-```
+---
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE).
+This project was licensed under the [MIT License](LICENSE).
+
+Thank you for your support as we continue to improve Databricks integrations within LangChain!
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # 🦜️🔗 LangChain Databricks (Deprecated)
 
+| Note: this package is deprecated in favor of the renamed `databricks-langchain` package ([repo](https://github.com/databricks/databricks-ai-bridge/tree/main/integrations/langchain), [package](https://pypi.org/project/databricks-langchain/)). |
+|-|
+
 This repository previously provided LangChain components to connect your LangChain application with various Databricks services.
 
 ## Deprecation Notice

--- a/libs/databricks/README.md
+++ b/libs/databricks/README.md
@@ -1,5 +1,8 @@
 # 🦜️🔗 LangChain Databricks (Deprecated)
 
+| Note: this package is deprecated in favor of the renamed `databricks-langchain` package ([repo](https://github.com/databricks/databricks-ai-bridge/tree/main/integrations/langchain), [package](https://pypi.org/project/databricks-langchain/)). |
+|-|
+
 This repository previously provided LangChain components to connect your LangChain application with various Databricks services.
 
 ## Deprecation Notice

--- a/libs/databricks/README.md
+++ b/libs/databricks/README.md
@@ -1,81 +1,48 @@
-# 🦜️🔗 LangChain Databricks
+# 🦜️🔗 LangChain Databricks (Deprecated)
 
-This repository provides LangChain components to connect your LangChain application with various Databricks services.
+This repository previously provided LangChain components to connect your LangChain application with various Databricks services.
 
-## Features
+## Deprecation Notice
 
-- **🤖 LLMs**: The `ChatDatabricks` component allows you to access chat endpoints hosted on [Databricks Model Serving](https://www.databricks.com/product/model-serving), including state-of-the-art models such as Llama3, Mixtral, and DBRX, as well as your own fine-tuned models.
-- **📐 Vector Store**: [Databricks Vector Search](https://www.databricks.com/product/machine-learning/vector-search) is a serverless similarity search engine that allows you to store a vector representation of your data, including metadata, in a vector database. With Vector Search, you can create auto-updating vector search indexes from Delta tables managed by Unity Catalog and query them with a simple API to return the most similar vectors.
-- **🔢 Embeddings**: Provides components for working with embedding models hosted on [Databricks Model Serving](https://www.databricks.com/product/model-serving).
-- **📊 MLflow Integration**: LangChain Databricks components is fully integrated with [MLflow](https://python.langchain.com/docs/integrations/providers/mlflow_tracking/), providing various LLMOps capabilities such as experiment tracking, dependency management, evaluation, and tracing (observability).
+The `langchain-databricks` package is now deprecated in favor of the consolidated package [`databricks-langchain`](https://pypi.org/project/databricks-langchain/). Please update your dependencies to use `databricks-langchain` going forward.
 
-**Note**: This repository will replace all Databricks integrations currently present in the `langchain-community` package. Users are encouraged to migrate to this repository as soon as possible.
+### Migration Guide
 
-## Installation
+#### What’s Changing?
 
-You can install the `langchain-databricks` package from PyPI.
+- All features previously provided by `langchain-databricks` are now available in `databricks-langchain`.
+- Future updates and new features will be released exclusively in `databricks-langchain`.
 
-```bash
-pip install -U langchain-databricks
-```
+#### How to Migrate
 
-If you are using this package outside Databricks workspace, you should configure credentials by setting the following environment variables:
+1. **Install the new package:**
 
-```bash
-export DATABRICKS_HOSTNAME="https://your-databricks-workspace"
-export DATABRICKS_TOKEN="your-personal-access-token"
-```
+    ```bash
+    pip install databricks-langchain
+    ```
 
-Instead of personal access token (PAT), you can also use [OAuth M2M authentication](https://docs.databricks.com/en/dev-tools/auth/oauth-m2m.html#language-Environment):
+2. **Update Imports:** Replace occurrences of `langchain_databricks` in your code with `databricks_langchain`. Example:
+   ```python
+   from databricks_langchain import ChatDatabricks
 
-```bash
-export DATABRICKS_HOSTNAME="https://your-databricks-workspace"
-export DATABRICKS_CLIENT_ID="your-service-principle-client-id"
-export DATABRICKS_CLIENT_SECRET="your-service-principle-secret"
-```
+   chat_model = ChatDatabricks(endpoint="databricks-meta-llama-3-70b-instruct")
+   response = chat_model.invoke("What is MLflow?")
+   print(response)
+   ```
 
-## Chat Models
+For more details, please refer to the [Langchain documentation](https://python.langchain.com/docs/integrations/providers/databricks/) and the [databricks-langchain package](https://pypi.org/project/databricks-langchain/). 
 
-`ChatDatabricks` is a Chat Model class to access chat endpoints hosted on Databricks, including state-of-the-art models such as Llama3, Mixtral, and DBRX, as well as your own fine-tuned models.
+---
 
-```python
-from langchain_databricks import ChatDatabricks
+## Contributing
 
-chat_model = ChatDatabricks(endpoint="databricks-meta-llama-3-70b-instruct")
-chat_model.invoke("Sing a ballad of LangChain.")
-```
+Contributions are now accepted in the `databricks-langchain` repository. Please refer to its [contribution guide](https://github.com/databricks/databricks-ai-bridge/tree/main/integrations/langchain) for more details.
 
-See the [usage example](https://python.langchain.com/docs/integrations/chat/databricks/) for more guidance on how to use it within your LangChain application.
+---
 
-**Note**: The LLM class [Databricks](https://python.langchain.com/docs/integrations/llms/databricks/) still lives in the `langchain-community` library. However, this class will be deprecated in the future and it is recommended to use `ChatDatabricks` to get the latest features.
+## License
 
-## Embeddings
+This project was licensed under the [MIT License](LICENSE).
 
-`DatabricksEmbeddings` is an Embeddings class to access text-embedding endpoints hosted on Databricks, including state-of-the-art models such as BGE, as well as your own fine-tuned models.
+Thank you for your support as we continue to improve Databricks integrations within LangChain!
 
-
-```python
-from langchain_databricks import DatabricksEmbeddings
-
-embeddings = DatabricksEmbeddings(endpoint="databricks-bge-large-en")
-```
-
-See the [usage example](https://python.langchain.com/docs/integrations/text_embedding/databricks) for more guidance on how to use it within your LangChain application.
-
-
-## Vector Search
-
-Databricks Vector Search is a serverless similarity search engine that allows you to store a vector representation of your data, including metadata, in a vector database. With Vector Search, you can create auto-updating vector search indexes from [Delta](https://docs.databricks.com/en/introduction/delta-comparison.html) tables managed by [Unity Catalog](https://www.databricks.com/product/unity-catalog) and query them with a simple API to return the most similar vectors.
-
-```python
-from langchain_databricks.vectorstores import DatabricksVectorSearch
-
-dvs = DatabricksVectorSearch(
-    index_name="<YOUR_INDEX_NAME>",
-    text_column="text",
-    columns=["source"]
-)
-docs = dvs.similarity_search("What is vector search?")
-```
-
-See the [usage example](https://python.langchain.com/docs/integrations/vectorstores/databricks_vector_search) for how to set up vector indices and integrate them with LangChain.

--- a/libs/databricks/langchain_databricks/chat_models.py
+++ b/libs/databricks/langchain_databricks/chat_models.py
@@ -60,7 +60,7 @@ logger = logging.getLogger(__name__)
 
 
 @deprecated(
-    since="0.1.2", removal="1.0", message="Use databricks_langchain.ChatDatabricks"
+    since="0.1.2", message="Use databricks_langchain.ChatDatabricks"
 )
 class ChatDatabricks(BaseChatModel):
     """Databricks chat model integration.

--- a/libs/databricks/langchain_databricks/chat_models.py
+++ b/libs/databricks/langchain_databricks/chat_models.py
@@ -17,6 +17,7 @@ from typing import (
     Union,
 )
 
+from langchain_core._api import deprecated
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models import BaseChatModel
 from langchain_core.language_models.base import LanguageModelInput
@@ -50,7 +51,6 @@ from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough
 from langchain_core.tools import BaseTool
 from langchain_core.utils.function_calling import convert_to_openai_tool
 from langchain_core.utils.pydantic import is_basemodel_subclass
-from langchain_core._api import deprecated
 from mlflow.deployments import BaseDeploymentClient  # type: ignore
 from pydantic import BaseModel, Field
 
@@ -60,7 +60,7 @@ logger = logging.getLogger(__name__)
 
 
 @deprecated(
-    since="0.1.2", message="Use databricks_langchain.ChatDatabricks"
+    since="0.1.2", message="Use databricks_langchain.ChatDatabricks", removal="1.0.0"
 )
 class ChatDatabricks(BaseChatModel):
     """Databricks chat model integration.

--- a/libs/databricks/langchain_databricks/chat_models.py
+++ b/libs/databricks/langchain_databricks/chat_models.py
@@ -50,6 +50,7 @@ from langchain_core.runnables import Runnable, RunnableMap, RunnablePassthrough
 from langchain_core.tools import BaseTool
 from langchain_core.utils.function_calling import convert_to_openai_tool
 from langchain_core.utils.pydantic import is_basemodel_subclass
+from langchain_core._api import deprecated
 from mlflow.deployments import BaseDeploymentClient  # type: ignore
 from pydantic import BaseModel, Field
 
@@ -58,6 +59,9 @@ from langchain_databricks.utils import get_deployment_client
 logger = logging.getLogger(__name__)
 
 
+@deprecated(
+    since="0.1.2", removal="1.0", message="Use databricks_langchain.ChatDatabricks"
+)
 class ChatDatabricks(BaseChatModel):
     """Databricks chat model integration.
 

--- a/libs/databricks/langchain_databricks/embeddings.py
+++ b/libs/databricks/langchain_databricks/embeddings.py
@@ -8,7 +8,7 @@ from langchain_databricks.utils import get_deployment_client
 
 
 @deprecated(
-    since="0.1.2", removal="1.0", message="Use databricks_langchain.ChatDatabricks"
+    since="0.1.2", message="Use databricks_langchain.DatabricksEmbeddings"
 )
 class DatabricksEmbeddings(Embeddings, BaseModel):
     """Databricks embedding model integration.

--- a/libs/databricks/langchain_databricks/embeddings.py
+++ b/libs/databricks/langchain_databricks/embeddings.py
@@ -1,14 +1,16 @@
 from typing import Any, Dict, Iterator, List
 
-from langchain_core.embeddings import Embeddings
 from langchain_core._api import deprecated
+from langchain_core.embeddings import Embeddings
 from pydantic import BaseModel, PrivateAttr
 
 from langchain_databricks.utils import get_deployment_client
 
 
 @deprecated(
-    since="0.1.2", message="Use databricks_langchain.DatabricksEmbeddings"
+    since="0.1.2",
+    message="Use databricks_langchain.DatabricksEmbeddings",
+    removal="1.0.0",
 )
 class DatabricksEmbeddings(Embeddings, BaseModel):
     """Databricks embedding model integration.

--- a/libs/databricks/langchain_databricks/embeddings.py
+++ b/libs/databricks/langchain_databricks/embeddings.py
@@ -1,11 +1,15 @@
 from typing import Any, Dict, Iterator, List
 
 from langchain_core.embeddings import Embeddings
+from langchain_core._api import deprecated
 from pydantic import BaseModel, PrivateAttr
 
 from langchain_databricks.utils import get_deployment_client
 
 
+@deprecated(
+    since="0.1.2", removal="1.0", message="Use databricks_langchain.ChatDatabricks"
+)
 class DatabricksEmbeddings(Embeddings, BaseModel):
     """Databricks embedding model integration.
 

--- a/libs/databricks/langchain_databricks/vectorstores.py
+++ b/libs/databricks/langchain_databricks/vectorstores.py
@@ -21,6 +21,7 @@ import numpy as np
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.vectorstores import VST, VectorStore
+from langchain_core._api import deprecated
 
 from langchain_databricks.utils import maximal_marginal_relevance
 
@@ -38,6 +39,9 @@ _NON_MANAGED_EMB_ONLY_MSG = (
 )
 
 
+@deprecated(
+    since="0.1.2", removal="1.0", message="Use databricks_langchain.ChatDatabricks"
+)
 class DatabricksVectorSearch(VectorStore):
     """Databricks vector store integration.
 

--- a/libs/databricks/langchain_databricks/vectorstores.py
+++ b/libs/databricks/langchain_databricks/vectorstores.py
@@ -40,7 +40,7 @@ _NON_MANAGED_EMB_ONLY_MSG = (
 
 
 @deprecated(
-    since="0.1.2", removal="1.0", message="Use databricks_langchain.ChatDatabricks"
+    since="0.1.2", message="Use databricks_langchain.DatabricksVectorSearch"
 )
 class DatabricksVectorSearch(VectorStore):
     """Databricks vector store integration.

--- a/libs/databricks/langchain_databricks/vectorstores.py
+++ b/libs/databricks/langchain_databricks/vectorstores.py
@@ -18,10 +18,10 @@ from typing import (
 )
 
 import numpy as np
+from langchain_core._api import deprecated
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.vectorstores import VST, VectorStore
-from langchain_core._api import deprecated
 
 from langchain_databricks.utils import maximal_marginal_relevance
 
@@ -40,7 +40,9 @@ _NON_MANAGED_EMB_ONLY_MSG = (
 
 
 @deprecated(
-    since="0.1.2", message="Use databricks_langchain.DatabricksVectorSearch"
+    since="0.1.2",
+    message="Use databricks_langchain.DatabricksVectorSearch",
+    removal="1.0.0",
 )
 class DatabricksVectorSearch(VectorStore):
     """Databricks vector store integration.


### PR DESCRIPTION
Update README to reflect that `langchain-databricks` should be deprecated, and mark classes with `@deprecated` annotations.